### PR TITLE
add GetValue methods like in Win32 RegistryKey class

### DIFF
--- a/Registry/Abstractions/RegistryKey.cs
+++ b/Registry/Abstractions/RegistryKey.cs
@@ -310,5 +310,17 @@ namespace Registry.Abstractions
 
             return sb.ToString();
         }
+
+        public object GetValue(string keyName)
+        {
+            return Values
+                ?.FirstOrDefault(v => v.ValueName.Equals(keyName, StringComparison.OrdinalIgnoreCase))
+                ?.ValueData;
+        }
+
+        public object GetValue(string keyName, object defaultValue)
+        {
+            return GetValue(keyName) ?? defaultValue;
+        }
     }
 }


### PR DESCRIPTION
RegistryKey class in Win32 namespace has methods to get values directly. To do the same here, one has to write boilerplate code such as `Values.FirstOrDefault(...).ValueData`. With this PR, the life of users of this library will hopefully be a little bit easier.