### PR TITLE
Initial Helium registry HiveType support

### DIFF
--- a/Registry/IRegistry.cs
+++ b/Registry/IRegistry.cs
@@ -35,5 +35,8 @@ public enum HiveTypeEnum
     [Description("userdiff")] Userdiff = 14,
     [Description("BBI")] Bbi = 15,
     [Description("VSMIDK")] Vsmidk = 16,
-    [Description("DEFAULT")] Default = 17
+    [Description("DEFAULT")] Default = 17,
+    [Description("User")] User = 18,
+    [Description("UserClasses")] UserClasses = 19,
+    [Description("settings")] settings = 20
 }

--- a/Registry/RegistryBase.cs
+++ b/Registry/RegistryBase.cs
@@ -164,6 +164,15 @@ public class RegistryBase : IRegistry
             case "userdiff": 
                 HiveType = HiveTypeEnum.Userdiff;
                 break;
+            case "user.dat": 
+                HiveType = HiveTypeEnum.User;
+                break;
+            case "userclasses.dat": 
+                HiveType = HiveTypeEnum.UserClasses;
+                break;
+            case "settings.dat": 
+                HiveType = HiveTypeEnum.settings;
+                break;
             default:
                 HiveType = HiveTypeEnum.Other;
                 break;

--- a/Registry/TransactionLog.cs
+++ b/Registry/TransactionLog.cs
@@ -159,6 +159,15 @@ public class TransactionLog
             case "userdiff": 
                 HiveType = HiveTypeEnum.Userdiff;
                 break;
+            case "user.dat": 
+                HiveType = HiveTypeEnum.User;
+                break;
+            case "userclasses.dat": 
+                HiveType = HiveTypeEnum.UserClasses;
+                break;
+            case "settings.dat": 
+                HiveType = HiveTypeEnum.settings;
+                break;
             default:
                 HiveType = HiveTypeEnum.Other;
                 break;


### PR DESCRIPTION
This adds initial support for the Helium registry hives found in UWP/ Windows Store Applications. Needed this for RECmd Batch Support.