### PR TITLE
Bugfix for RegUwpArrayPoint, RegUwpArraySize and RegUwpArrayRect

### DIFF
--- a/Registry/Cells/VkCellRecord.cs
+++ b/Registry/Cells/VkCellRecord.cs
@@ -724,7 +724,7 @@ public class VkCellRecord : ICellTemplate, IRecordBase
                         var valPoint = new List<string>();
                         for (var i = 0; i < numRecs; i++)
                         {
-                            valPoint.Add($"X: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i*8))}, Y: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 8) + 4)}");
+                            valPoint.Add($"{{X: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i*8))}, Y: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 8) + 4)}}}");
                         }
                         val = string.Format("[{0}]", string.Join(",", valPoint));
                         break;
@@ -733,7 +733,7 @@ public class VkCellRecord : ICellTemplate, IRecordBase
                         var valSize = new List<string>();
                         for (var i = 0; i < numRecs; i++)
                         {
-                            valSize.Add($"Width: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i*8))}, Height: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 8) + 4)}");
+                            valSize.Add($"{{Width: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i*8))}, Height: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 8) + 4)}}}");
                         }
                         val = string.Format("[{0}]", string.Join(",", valSize));
                         break;
@@ -742,7 +742,7 @@ public class VkCellRecord : ICellTemplate, IRecordBase
                         var valRect = new List<string>();
                         for (var i = 0; i < numRecs; i++)
                         {
-                            valRect.Add($"X: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i*16))}, Y: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 16) + 4)}, Width: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 16) + 8)}, Height: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 16) + 12)}");
+                            valRect.Add($"{{X: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i*8))}, Y: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 8) + 4)}, Width: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 8) + 8)}, Height: {BitConverter.ToSingle(localDbl, _internalDataOffset + (i * 8) + 12)}}}");
                         }
                         val = string.Format("[{0}]", string.Join(",", valRect));
                         break;


### PR DESCRIPTION
Fixes output of RegUwpArrayPoint, RegUwpArraySize and RegUwpArrayRect. RegUwpArrayRect accidently had values set to 16 instead of 8.

Before RegUwpArrayPoint:
[X: 0, Y: 0,X: 10, Y: 20,X: -5, Y: 15]
After RegUwpArrayPoint:
[{X: 0, Y: 0},{X: 10, Y: 20},{X: -5, Y: 15}]

Before RegUwpArrayRect: 
[X: 0, Y: 0, Width: 100, Height: 200,X: 10, Y: 10, Width: 50, Height: 50,X: 5, Y: 5, Width: 20, Height: 40]
After RegUwpArrayRect: 
[{X: 0, Y: 0, Width: 100, Height: 200},{X: 100, Y: 200, Width: 10, Height: 10},{X: 10, Y: 10, Width: 50, Height: 50}]